### PR TITLE
Lower coverage threshold and validate config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,9 @@ coverage:
   round: down
   range: "80...100"
   status:
-    project: yes
+    project:
+      default:
+        target: 95
     patch: yes
     changes: no
 parsers:

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 set -e
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 CONTAINER_TAG="did-it-run"
 
 cargo test --verbose --all
+
+codecov_validate_output=$(curl \
+  --data-binary \
+  @$DIR/.codecov.yml \
+  https://codecov.io/validate)
+if [[ $codecov_validate_output != *"Valid!"* ]]; then
+  echo $codecov_validate_output
+  exit 1
+fi
 
 docker build \
   --tag $CONTAINER_TAG \


### PR DESCRIPTION
Temporary fix for #10 (Coverage incorrectly claims some lines are "not hit") by lowering the coverage threshold to 95%.

Also adds a test to validate the `.codecov.yml` config file with Codecov's online validator.