### PR TITLE
Install binary in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
+  - cargo install --force --path did_it_run
   - ./run-test-scripts.sh
 jobs:
   include:


### PR DESCRIPTION
#13 introduced a CI regression where `run-test-scripts.sh` will fail because the binary is not installed (bug masked by Travis CI's caching).