### PR TITLE
Use nightly for style check if RUSTUP_TOOLCHAIN is not provided

### DIFF
--- a/.build/azure-pipelines.yml
+++ b/.build/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
   variables:
   - group: codecov
   - name: rustup_toolchain
-    value: nightly
+    value: nightly-2019-05-01
   steps:
   - script: |
       sudo apt-get update

--- a/check-style.sh
+++ b/check-style.sh
@@ -2,9 +2,11 @@
 STATUS=0
 sort --check CONTRIBUTORS || STATUS=1
 sort --check rustfmt.toml || STATUS=1
-# Fall back to an older nightly if the current version doesn't have rustfmt and
-# clippy
-cargo +nightly fmt --all -- --check || STATUS=1
+if [ -z "$RUSTUP_TOOLCHAIN" ]; then
+  cargo +nightly fmt --all -- --check || STATUS=1
+else
+  cargo fmt --all -- --check || STATUS=1
+fi
 ! git \
   --no-pager \
   grep \
@@ -19,5 +21,9 @@ cargo +nightly fmt --all -- --check || STATUS=1
       ':!rustfmt.toml' \
       ':!check-style.sh' ||
   STATUS=1
-cargo +nightly clippy -- -D warnings || STATUS=1
+if [ -z "$RUSTUP_TOOLCHAIN" ]; then
+  cargo +nightly clippy -- -D warnings || STATUS=1
+else
+  cargo clippy -- -D warnings || STATUS=1
+fi
 exit $STATUS


### PR DESCRIPTION
Use `+nightly` for style checks only if the `RUSTUP_TOOLCHAIN` environment variable is not provided.

Force `nightly-2019-05-01` since `clippy` and `rustfmt` often break on the latest nightly, therefore failing CI. If there is ever a difference between the 2019-05-01 style and the current version, we'll need to make a new PR to update the date.