### PR TITLE
rustfmt `binop_separator`

### DIFF
--- a/did_it_run/src/duration_format.rs
+++ b/did_it_run/src/duration_format.rs
@@ -81,9 +81,9 @@ mod test {
         assert_eq!(duration_format(&secs(SECONDS_PER_DAY)), "1d 0h 0m");
         assert_eq!(
             duration_format(&secs(
-                3 * SECONDS_PER_DAY
-                    + 14 * SECONDS_PER_HOUR
-                    + 16 * SECONDS_PER_MINUTE
+                3 * SECONDS_PER_DAY +
+                    14 * SECONDS_PER_HOUR +
+                    16 * SECONDS_PER_MINUTE
             )),
             "3d 14h 16m"
         );

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+binop_separator = "Back"
 condense_wildcard_suffixes = true
 edition = "2018"
 error_on_line_overflow = true


### PR DESCRIPTION
rustfmt: Put binary separators at the back of the line for multiline expressions.